### PR TITLE
:sparkles: new binary to compute memory usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,3 +75,4 @@ COPY Makefile .
 COPY python.manifest.template .
 COPY mse-run.sh /usr/local/bin/mse-run
 COPY mse-test.sh /usr/local/bin/mse-test
+COPY mse-memory.py /usr/local/bin/mse-memory

--- a/README.md
+++ b/README.md
@@ -133,3 +133,25 @@ $ curl http://127.0.0.1:5000
 ```
 
 To use your `secrets.json`, just add `-v secrets.json:/root/.cache/mse/secrets.json` to mount the file.
+
+
+## Determine the enclave memory size of your image
+
+Some files contained in the docker are mounted into the enclave: libs, etc. 
+These files takes some memory spaces from the enclave size you have declared. The remaining space is the effective memory your app can use.
+
+You can compute the effective memory by adding `--memory` in the previous commands. For example:
+
+```console
+$ docker run --rm \
+    -v /tmp/app.tar:/tmp/app.tar \
+    --entrypoint mse-run \
+    mse-flask:2.2.2 --size 8G \
+                    --code /tmp/app.tar \
+                    --host localhost \
+                    --application app:app \
+                    --uuid 533a2b83-4bc5-4a9c-955e-208c530bfd15 \
+                    --self-signed 1769155711 \
+                    --dry-run
+                    --memory
+```

--- a/mse-memory.py
+++ b/mse-memory.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import sys
+
+import toml
+
+units = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+
+
+def human_readable_size(size):
+    """Get a size as a human readable string-size."""
+    for i, unit in enumerate(units.keys()):
+        if size < 1024.0 or i == (len(units) - 1):
+            break
+        size /= 1024.0
+    return f"{size:.2f}{unit}"
+
+
+def parse_human_readable(size):
+    """Convert a human readable string-size to an integer."""
+    unit = size[-1]
+    number = size[:-1]
+    return int(float(number) * units[unit])
+
+
+def run(manifest_path: Path):
+    """Read the manifest.sgx to determine the effective enclave size."""
+    manifest = toml.load(manifest_path)
+
+    pal_size = 64 * 1024 * 1024 + parse_human_readable(
+        manifest["loader"]["pal_internal_mem_size"]
+    )
+    enclave_size = parse_human_readable(manifest["sgx"]["enclave_size"])
+
+    print("Declared enclave size:", human_readable_size(enclave_size))
+    print("Gramine internal memory size:", human_readable_size(pal_size))
+
+    files_size = 0
+    for item in manifest["sgx"]["trusted_files"]:
+        path = Path(item["uri"].split(":")[1])
+        if path.is_file():
+            files_size += path.stat().st_size  # in bytes
+
+    print("Files size:", human_readable_size(files_size))
+
+    print(
+        "Available app memory size:",
+        human_readable_size(enclave_size - pal_size - files_size),
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <python.manifest.sgx>")
+        exit(1)
+
+    run(sys.argv[1])


### PR DESCRIPTION
A new command to compute the effective enclave size from a `python.enclave.sgx`. 

I suggest to run this command when we call `mse-run` and print the info in the stdout.